### PR TITLE
feat: treat nested block comment

### DIFF
--- a/Mdgen/ConvertToMd.lean
+++ b/Mdgen/ConvertToMd.lean
@@ -6,47 +6,113 @@ syntax ident "++=" term : doElem
 macro_rules
   | `(doElem| $x:ident ++= $e:term) => `(doElem| ($x) := ($x) ++ ($e))
 
+structure LeveledLine where
+  /-- text content -/
+  content : String
+
+  /-- nest level -/
+  level : Nat
+  deriving Repr, BEq
+
+instance : ToString LeveledLine where
+  toString := fun l => s!"content: \n{l.content}\n, level: {l.level}"
+
+/-- Receive a list of codes and count the nesting of block and sectioning comments.
+* The corresponding opening and closing brackets should have the same level.
+* Also handles the exclusion of ignored targets.
+-/
+def analysis (lines : List String) : List LeveledLine := Id.run do
+  let mut level := 0
+  let mut res : List LeveledLine := []
+  for line in lines do
+    if line.endsWith "--#" then
+      continue
+    if line.startsWith "/-" && ! line.startsWith "/--" then
+      level := level + 1
+    res := {content := line, level := level} :: res
+    if line.endsWith "-/" then
+      level := level - 1
+  return res.reverse
+
+namespace analysis
+
+def runTest (input : List String) (expected : List Nat) (title := "") : IO Unit :=
+  let output := analysis input
+  if output.map (·.level) = expected then
+    IO.println s!"{title} test passed!"
+  else
+    throw <| .userError s!"Test failed: \n{output}"
+
+#eval runTest
+  (title := "nested block comment")
+  [
+    "/-",
+      "/- hoge",
+      "-/",
+      "/-",
+      "-/",
+      "hoge",
+    "-/",
+    "foo"
+  ]
+  [1, 2, 2, 2, 2, 1, 1, 0]
+
+#eval runTest
+  (title := "sectioning comment and nested block comment")
+  [
+    "/-! hoge fuga",
+      "/- foo! -/",
+    "-/",
+    "def foo := 1",
+  ]
+  [1, 2, 1, 0]
+
+#eval runTest
+  (title := "one line doc comment")
+  [
+    "/-- hoge -/",
+    "def hoge := \"hoge\"",
+  ]
+  [0, 0]
+
+#eval runTest
+  (title := "multi line doc comment")
+  [
+    "/-- hoge",
+    "fuga -/",
+    "def hoge := 42",
+  ]
+  [0, 0, 0]
+
+end analysis
+
 /-- A chunk of grouped code for conversion to markdown. -/
 structure Block where
   content : String
   toCodeBlock : Bool
   deriving Repr
 
-private def buildBlocks (lines : List String) : List Block := Id.run do
-  let mut toCodeBlock := true
-  let mut blocks : List Block := []
-  let mut content := ""
-  for ⟨i, line⟩ in lines.enum do
-    if line.endsWith "--#" then
-      continue
+instance : ToString Block where
+  toString := fun b =>
+    s!"content: \n{b.content}\n toCodeBlock: {b.toCodeBlock}\n\n"
 
-    if line.startsWith "/-" && ! line.startsWith "/--" then
-      if ! toCodeBlock then
-        panic!
-          "Nested lean commentary sections not allowed in:\n" ++
-          s!" line {i+1}: {line}"
+partial def buildBlocks (lines : List LeveledLine) : List Block :=
+  match lines with
+  | [] => []
+  | ⟨_, level₀⟩ :: _ =>
+    let (fst, snd) := if level₀ == 0
+        then lines.span (·.level == 0)
+        else lines.span (·.level >= 1)
+    let fstBlock : Block := {
+      content := fst.map (·.content)
+        |>.map (· ++ "\n")
+        |>.foldl (· ++ ·) ""
+        |>.trim,
+      toCodeBlock := (level₀ == 0)
+    }
+    fstBlock :: buildBlocks snd
 
-      if content != "" then
-        blocks := {content := content.trim, toCodeBlock := toCodeBlock} :: blocks
-      toCodeBlock := ! toCodeBlock
-      content := line ++ "\n"
-
-      if line.endsWith "-/" then
-        blocks := {content := content.trim, toCodeBlock := toCodeBlock} :: blocks
-        toCodeBlock := ! toCodeBlock
-        content := ""
-
-    else if line.endsWith "-/" && ! toCodeBlock then
-      content ++= line
-      blocks := {content := content.trim, toCodeBlock := toCodeBlock} :: blocks
-      toCodeBlock := ! toCodeBlock
-      content := ""
-    else
-      content ++= line ++ "\n"
-
-  if content != "" then
-    blocks := {content := content.trim, toCodeBlock := toCodeBlock} :: blocks
-  return blocks.reverse
+#eval (buildBlocks <| analysis ["/-", "foo", "bar", "-/", "/-", "baz", "-/"]) |>.map (·.content)
 
 /-- markdown text -/
 abbrev Md := String
@@ -59,14 +125,24 @@ private def Block.toMd (b : Block) : Md :=
   else
     let separator := if b.content.startsWith "/-!" then "/-!" else "/-"
     b.content
-      |> (String.splitOn · separator)
-      |> List.drop 1
-      |> List.foldl (· ++ ·) ""
-      |> (String.splitOn · "-/")
-      |> List.dropLast
-      |> List.foldl (· ++ ·) ""
+      |> (String.drop · separator.length)
+      |> (String.dropRight · "-/".length)
       |> String.trim
       |> (· ++ "\n\n")
+
+#eval Block.toMd {
+    content := "/-\nfoo\nbar\n-/\n/-\nbaz\n-/"
+    toCodeBlock := false
+  }
+
+instance : ToString Block where
+  toString := fun b =>
+    s!"content: \n{b.content}\n toCodeBlock: {b.toCodeBlock}\n\n"
+
+#eval Block.toMd {
+    content := "/-! # This is a test \n/-\nhoge\n-/\n-/",
+    toCodeBlock := false
+  }
 
 private def mergeBlocks (blocks : List Block) : Md :=
   let res := blocks
@@ -76,7 +152,8 @@ private def mergeBlocks (blocks : List Block) : Md :=
 
 /-- convert lean contents to markdown contents. -/
 def convertToMd (lines : List String) : Md :=
-  let blocks := buildBlocks lines
+  let blocks := buildBlocks <| analysis lines
+  dbg_trace s!"blocks: {blocks}"
   mergeBlocks blocks
 
 namespace ConvertToMd
@@ -89,7 +166,7 @@ def runTest (input : List String) (expected : List String) (title := "") : IO Un
   if output = expected.withBreakLine then
     IO.println s!"{title} test passed!"
   else
-    throw <| .userError s!"Test failed: {output}"
+    throw <| .userError s!"Test failed: \n{output}"
 
 #eval runTest
   (title := "inline comment")
@@ -185,5 +262,36 @@ def runTest (input : List String) (expected : List String) (title := "") : IO Un
     "  monyo",
     "```"
   ]
+
+#eval runTest
+  (title := "nested block comment")
+  [
+    "/-",
+    "this is a test",
+    "/- nested comment -/",
+    "of nested block comment -/"
+  ]
+  [
+    "this is a test",
+    "/- nested comment -/",
+    "of nested block comment"
+  ]
+
+-- #eval runTest
+--   (title := "raw code block")
+--   [
+--     "/-",
+--     "```lean",
+--     "/- this is test -/",
+--     "```",
+--     "-/",
+--     "/- hoge -/",
+--   ]
+--   [
+--     "```lean",
+--     "/- this is test -/",
+--     "```",
+--     "hoge"
+--   ]
 
 end ConvertToMd

--- a/Mdgen/ConvertToMd.lean
+++ b/Mdgen/ConvertToMd.lean
@@ -156,7 +156,6 @@ private def mergeBlocks (blocks : List Block) : Md :=
 /-- convert lean contents to markdown contents. -/
 def convertToMd (lines : List String) : Md :=
   let blocks := buildBlocks <| analysis lines
-  dbg_trace s!"blocks: {blocks}"
   mergeBlocks blocks
 
 namespace ConvertToMd

--- a/Mdgen/ConvertToMd.lean
+++ b/Mdgen/ConvertToMd.lean
@@ -324,4 +324,19 @@ def runTest (input : List String) (expected : List String) (title := "") : IO Un
     "hoge"
   ]
 
+#eval runTest
+  (title := "indent in raw code block")
+  [
+    "/-",
+    "```lean",
+    "  hoge",
+    "```",
+    "-/"
+  ]
+  [
+    "```lean",
+    "  hoge",
+    "```"
+  ]
+
 end ConvertToMd

--- a/Mdgen/ConvertToMd.lean
+++ b/Mdgen/ConvertToMd.lean
@@ -145,19 +145,9 @@ private def Block.toMd (b : Block) : Md :=
       |> String.trim
       |> (· ++ "\n\n")
 
-#eval Block.toMd {
-    content := "/-\nfoo\nbar\n-/\n/-\nbaz\n-/"
-    toCodeBlock := false
-  }
-
 instance : ToString Block where
   toString := fun b =>
     s!"content: \n{b.content}\n toCodeBlock: {b.toCodeBlock}\n\n"
-
-#eval Block.toMd {
-    content := "/-! # This is a test \n/-\nhoge\n-/\n-/",
-    toCodeBlock := false
-  }
 
 private def mergeBlocks (blocks : List Block) : Md :=
   let res := blocks

--- a/Mdgen/ConvertToMd.lean
+++ b/Mdgen/ConvertToMd.lean
@@ -264,6 +264,17 @@ def runTest (input : List String) (expected : List String) (title := "") : IO Un
   ]
 
 #eval runTest
+  (title := "block comment repeated")
+  [
+    "/- hoge -/",
+    "/- fuga -/",
+  ]
+  [
+    "hoge",
+    "fuga"
+  ]
+
+#eval runTest
   (title := "nested block comment")
   [
     "/-",

--- a/Mdgen/ConvertToMd.lean
+++ b/Mdgen/ConvertToMd.lean
@@ -108,17 +108,15 @@ def listShift {α : Type} (x : List α × List α) : List α × List α :=
 partial def buildBlocks (lines : List RichLine) : List Block :=
   match lines with
   | [] => []
-  | line :: _ => Id.run do
+  | line :: _ =>
     let ⟨_, level, _⟩ := line
 
-    let mut splited := (
+    let splited := (
       if level == 0 then
         lines.span (fun x => x.level == 0)
       else
-        lines.span (fun x => x.level > 1 || ! x.close)
+        listShift <| lines.span (fun x => x.level > 1 || ! x.close)
     )
-    if level != 0 then
-      splited := listShift splited
     let fstBlock : Block := {
       content := splited.fst
         |>.map (·.content)
@@ -127,7 +125,7 @@ partial def buildBlocks (lines : List RichLine) : List Block :=
         |>.trim,
       toCodeBlock := (level == 0)
     }
-    return fstBlock :: buildBlocks splited.snd
+    fstBlock :: buildBlocks splited.snd
 
 /-- markdown text -/
 abbrev Md := String

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Don't forget to run `lake update mdgen` after editing the `lakefile`. And simply
 
 * The comments enclosed with an `/-! ... -/` or `/- ... -/` are converted as ground text.
 
+* Nested block comments can also be handled.
+
 * The inline comment, doc comment and non-comment parts are converted to lean code blocks.
 
 * Lines ending with `--#` are ignored.

--- a/Test/Exp/First.md
+++ b/Test/Exp/First.md
@@ -39,3 +39,12 @@ example (h : P) : P ∨ Q := by
   apply Or.inl
   exact h
 ```
+
+## nested comment
+Here is a sample of nested block comment:
+/- Hi. I am a nested comment! -/
+
+Here is another example of nested block comment:
+```lean
+/- wao. this is another sample!! -/
+```

--- a/Test/Src/First.lean
+++ b/Test/Src/First.lean
@@ -42,3 +42,13 @@ example (h : P) : P ∨ Q := by
   -/
   apply Or.inl
   exact h
+
+/- ## nested comment
+Here is a sample of nested block comment:
+/- Hi. I am a nested comment! -/
+
+Here is another example of nested block comment:
+```lean
+/- wao. this is another sample!! -/
+```
+-/


### PR DESCRIPTION
resolve #10

Nested block comments can now be handled.

```lean
#eval runTest
  (title := "nested block comment")
  [
    "/-",.
    "this is a test",.
    "/- nested comment -/",.
    "of nested block comment -/"
  ]
  [
    "this is a test", "/- nested comment".
    "/- nested comment -/", "of nested block comment".
    "of nested block comment".
  ]
```